### PR TITLE
feat: add suggestion ids and toggleable input

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ app.use(Chat)
       :open="openChat"
       :showEmoji="true"
       :showFile="true"
+      :showTextInput="showTextInput"
       :showEdition="true"
       :showDeletion="true"
       :deletionConfirmation="true"
@@ -196,6 +197,7 @@ For more detailed examples see the demo folder.
 | showEmoji                   | Boolean | A bool indicating whether or not to show the emoji button
 | showEmojiInText             | Boolean | A bool indicating whether or not to send emoji directly as a message as opposed to inserting them into the user input
 | showFile                    | Boolean | A bool indicating whether or not to show the file chooser button
+| showTextInput               | Boolean | A bool indicating whether or not to show the text input field
 | showDeletion                | Boolean | A bool indicating whether or not to show the edit button for a message
 | showConfirmationDeletion    | Boolean | A bool indicating whether or not to show the confirmation text when we remove a message
 | confirmationDeletionMessage | String | The message you want to show when confirming the deletion
@@ -311,7 +313,7 @@ Message objects are rendered differently depending on their type. Currently, onl
 
 #### Quick replies
 
-When sending a message, you can provide a set of sentences that will be displayed in the user chat as quick replies. Adding in the message object a `suggestions` field with the value an array of strings will trigger this functionality
+When sending a message, you can provide a set of sentences that will be displayed in the user chat as quick replies. Adding in the message object a `suggestions` field with the value an array of strings or key-value objects will trigger this functionality. When using objects, each object should have the form `{ 'Displayed text': id }` and only the text will be shown in the chat. The corresponding id will be available in the `onMessageWasSent` callback as `suggestionId`.
 
 ```javascript
 {
@@ -322,7 +324,7 @@ When sending a message, you can provide a set of sentences that will be displaye
     text: 'some text',
     meta: '06-16-2019 12:43'
   },
-  suggestions: ['some quick reply', ..., 'another one']
+  suggestions: [{ 'Option A': 11 }, { OptionB: 12 }, 'another one']
 }
 ```
 

--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -16,6 +16,7 @@
       :show-launcher="true"
       :show-emoji="true"
       :show-file="true"
+      :show-text-input="showTextInput"
       :show-typing-indicator="showTypingIndicator"
       :show-edition="true"
       :show-deletion="true"
@@ -116,6 +117,7 @@ import Header from './Header.vue'
 import Footer from './Footer.vue'
 import TestArea from './TestArea.vue'
 import availableColors from './colors'
+import axios from 'axios'
 
 export default {
   name: 'App',
@@ -137,7 +139,8 @@ export default {
       chosenColor: null,
       alwaysScrollToBottom: true,
       messageStyling: true,
-      userIsTyping: false
+      userIsTyping: false,
+      showTextInput: false
     }
   },
   computed: {
@@ -172,6 +175,10 @@ export default {
     },
     onMessageWasSent(message) {
       this.messageList = [...this.messageList, Object.assign({}, message, {id: Math.random()})]
+      if (message.suggestionId) {
+        axios.post('/api/suggestions', {id: message.suggestionId})
+        this.showTextInput = true
+      }
     },
     openChat() {
       this.isChatOpen = true

--- a/demo/src/messageHistory.js
+++ b/demo/src/messageHistory.js
@@ -99,9 +99,8 @@ export default [
     id: 21,
     data: {text: `What about suggestions?`},
     suggestions: [
-      'Looks good!',
-      "It's OK.",
-      'Uhh.. Do I really have to say something?',
+      { 'Option A': 11 },
+      { OptionB: 12 },
       "This suggestion is way too long for css purpose. Let's make it long... Longer, and more and more.. Never ending."
     ]
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "autolinker": "^4.1.0",
+    "axios": "^1.7.7",
     "emoji-js": "^3.8.1",
     "escape-goat": "^4.0.0",
     "imagemin": "^9.0.0",

--- a/src/ChatWindow.vue
+++ b/src/ChatWindow.vue
@@ -63,6 +63,7 @@
       :on-submit="onUserInputSubmit"
       :suggestions="getSuggestions()"
       :show-file="showFile"
+      :show-text-input="showTextInput"
       :placeholder="placeholder"
       :colors="colors"
       :accepted-file-types="acceptedFileTypes"
@@ -96,6 +97,10 @@ export default {
       default: false
     },
     showFile: {
+      type: Boolean,
+      default: false
+    },
+    showTextInput: {
       type: Boolean,
       default: false
     },

--- a/src/Launcher.vue
+++ b/src/Launcher.vue
@@ -22,6 +22,7 @@
       :show-emoji="showEmoji"
       :show-emoji-in-text="showEmojiInText"
       :show-file="showFile"
+      :show-text-input="showTextInput"
       :show-confirmation-deletion="showConfirmationDeletion"
       :confirmation-deletion-message="confirmationDeletionMessage"
       :show-header="showHeader"
@@ -154,6 +155,10 @@ export default {
       required: false
     },
     showFile: {
+      type: Boolean,
+      default: false
+    },
+    showTextInput: {
       type: Boolean,
       default: false
     },

--- a/src/Suggestions.vue
+++ b/src/Suggestions.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="sc-suggestions-row" :style="{background: colors.messageList.bg}">
     <button
-      v-for="(suggestion, idx) in suggestions"
+      v-for="(suggestion, idx) in normalizedSuggestions"
       :key="idx"
       class="sc-suggestions-element"
       :style="{
@@ -10,7 +10,7 @@
       }"
       @click="$emit('sendSuggestion', suggestion)"
     >
-      {{ suggestion }}
+      {{ suggestion.text }}
     </button>
   </div>
 </template>
@@ -27,8 +27,18 @@ export default {
       required: true
     }
   },
-  data() {
-    return {}
+  computed: {
+    normalizedSuggestions() {
+      return this.suggestions.map((s) => {
+        if (typeof s === 'string') {
+          return {text: s}
+        } else if (s && typeof s === 'object') {
+          const key = Object.keys(s)[0]
+          return {text: key, id: s[key]}
+        }
+        return {text: ''}
+      })
+    }
   }
 }
 </script>

--- a/src/UserInput.vue
+++ b/src/UserInput.vue
@@ -2,7 +2,7 @@
   <div>
     <Suggestions :suggestions="suggestions" :colors="colors" @sendSuggestion="_submitSuggestion" />
     <div
-      v-if="file"
+      v-if="file && showTextInput"
       class="file-container"
       :style="{
         backgroundColor: colors.userInput.bg,
@@ -44,6 +44,7 @@
       </div>
     </div>
     <form
+      v-if="showTextInput"
       class="sc-user-input"
       :class="{active: inputActive}"
       :style="{background: colors.userInput.bg}"
@@ -164,6 +165,10 @@ export default {
       type: Boolean,
       default: () => false
     },
+    showTextInput: {
+      type: Boolean,
+      default: () => false
+    },
     onSubmit: {
       type: Function,
       required: true
@@ -262,7 +267,13 @@ export default {
       })
     },
     _submitSuggestion(suggestion) {
-      this.onSubmit({author: 'me', type: 'text', data: {text: suggestion}})
+      const payload = typeof suggestion === 'object' ? suggestion : {text: suggestion}
+      this.onSubmit({
+        author: 'me',
+        type: 'text',
+        data: {text: payload.text},
+        suggestionId: payload.id
+      })
     },
     _checkSubmitSuccess(success) {
       if (Promise !== undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,10 +1002,17 @@
     debug "^4.3.1"
     minimatch "^3.1.2"
 
-"@eslint/core@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.10.0.tgz#23727063c21b335f752dbb3a16450f6f9cbc9091"
-  integrity sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==
+"@eslint/core@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.13.0.tgz#bf02f209846d3bf996f9e8009db62df2739b458c"
+  integrity sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==
+  dependencies:
+    "@types/json-schema" "^7.0.15"
+
+"@eslint/core@^0.9.0":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint/core/-/core-0.9.1.tgz#31763847308ef6b7084a4505573ac9402c51f9d1"
+  integrity sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==
   dependencies:
     "@types/json-schema" "^7.0.15"
 
@@ -1024,22 +1031,22 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.18.0":
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.18.0.tgz#3356f85d18ed3627ab107790b53caf7e1e3d1e84"
-  integrity sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==
+"@eslint/js@9.17.0":
+  version "9.17.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-9.17.0.tgz#1523e586791f80376a6f8398a3964455ecc651ec"
+  integrity sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==
 
 "@eslint/object-schema@^2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.5.tgz#8670a8f6258a2be5b2c620ff314a1d984c23eb2e"
   integrity sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==
 
-"@eslint/plugin-kit@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz#ee07372035539e7847ef834e3f5e7b79f09e3a81"
-  integrity sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==
+"@eslint/plugin-kit@^0.2.3":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz#47488d8f8171b5d4613e833313f3ce708e3525f8"
+  integrity sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==
   dependencies:
-    "@eslint/core" "^0.10.0"
+    "@eslint/core" "^0.13.0"
     levn "^0.4.1"
 
 "@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
@@ -2505,6 +2512,11 @@ async@^2.6.2:
   dependencies:
     lodash "^4.17.14"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 at-least-node@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz"
@@ -2535,6 +2547,15 @@ available-typed-arrays@^1.0.7:
   integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
   dependencies:
     possible-typed-array-names "^1.0.0"
+
+axios@^1.7.7:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
+  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
 
 babel-loader@^8.2.2:
   version "8.4.1"
@@ -3026,6 +3047,13 @@ colorette@^2.0.10, colorette@^2.0.20:
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
@@ -3427,6 +3455,11 @@ define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -4348,12 +4381,28 @@ follow-redirects@^1.0.0:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
+follow-redirects@^1.15.6:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
+  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -5860,7 +5909,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -6977,6 +7026,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary
- support suggestion items as key/value pairs and emit `suggestionId`
- add `showTextInput` prop to hide or reveal the user text field
- demo sends selected suggestion ids via Axios and exposes the new option

## Testing
- `yarn lint` *(fails: Invalid Options - Unknown options: extensions, ignorePath, reportUnusedDisableDirectives, resolvePluginsRelativeTo, rulePaths, useEslintrc)*
- `yarn build:prod`


------
https://chatgpt.com/codex/tasks/task_e_689df2aa01ec833083846d9358c863f3